### PR TITLE
return error if passed nil net.Addr

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -13,6 +13,10 @@ var errIncorrectNetAddr = fmt.Errorf("incorrect network addr conversion")
 
 // FromNetAddr converts a net.Addr type to a Multiaddr.
 func FromNetAddr(a net.Addr) (ma.Multiaddr, error) {
+	if a == nil {
+		return nil, fmt.Errorf("nil multiaddr")
+	}
+
 	switch a.Network() {
 	case "tcp", "tcp4", "tcp6":
 		ac, ok := a.(*net.TCPAddr)


### PR DESCRIPTION
Ive seen a lot of tests in go-ipfs panic as a result of this function being passed a nil `net.Addr`. Generally as a result of this line: https://github.com/jbenet/go-multiaddr-net/blob/master/net.go#L38   `nconn` for some reason returns a nil value.

This will prevent it from panicking, but doesnt address the deeper problem of 'why does it return a nil address?'